### PR TITLE
Fix: fall back through clients if local full node is unreachable on Windows

### DIFF
--- a/python/xkv8/xkv8r.py
+++ b/python/xkv8/xkv8r.py
@@ -455,9 +455,18 @@ async def mine():
 
     while True:
         try:
-            blockchain_state = await client.get_blockchain_state()
-            if not blockchain_state.success:
-                print("Failed to get blockchain state")
+            blockchain_state = None
+            for c in clients:
+                try:
+                    res = await c.get_blockchain_state()
+                    if res.success:
+                        client = c
+                        blockchain_state = res
+                        break
+                except Exception:
+                    continue
+            if blockchain_state is None:
+                print("Failed to get blockchain state from any client")
                 await asyncio.sleep(ERROR_SLEEP * (0.5 + random.random()))
                 continue
 


### PR DESCRIPTION
## Root Cause

Chia's full node RPC uses **mutual TLS (mTLS)** — both the server and the client must present certificates. On Windows, `reqwest` (inside `chia_wallet_sdk`) uses the native Windows TLS stack (Schannel) to handle this. Schannel does not reliably handle client certificate authentication in the way Chia's RPC requires, causing the connection to fail even when:

- Port 8555 is confirmed open and listening
- TLS certificates are present at the correct path
- `CHIA_ROOT` is correctly set
- The Chia CA certificate is already present in the Windows Trusted Root store (confirmed via `certutil`)

The fix requires `chia_wallet_sdk` to use `rustls` instead of `native-tls` as the `reqwest` TLS backend — this is an upstream change outside the scope of `xkv8`.

## What this PR does

Applies the same multi-client fallback pattern to `get_blockchain_state` that already exists in `get_coin_records_by_puzzle_hash`. If the local full node client fails (for any reason, including the Windows mTLS issue), the miner silently falls back to the public coinset endpoint rather than looping with errors indefinitely.

This means Windows users with `LOCAL_FULL_NODE=1` set will mine successfully via the public endpoint instead of being stuck in an error loop — without any change to their configuration.

## Tested

Proven on Windows 10 with a local full node running. Before this fix: continuous TLS errors, no mining. After this fix: miner successfully submitted a spend bundle at block height **8527634** (Status=PENDING).